### PR TITLE
Use fetch instead of axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shopify-product-scraper",
-  "version": "1.0.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shopify-product-scraper",
-      "version": "1.0.2",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.3.5",

--- a/package.json
+++ b/package.json
@@ -1,24 +1,21 @@
 {
   "name": "shopify-product-scraper",
   "version": "1.4.0",
-  "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts"
-  },
   "author": "MMinusOne",
   "repository": {
     "url": "https://github.com/MMinusOne/shopify-product-scraper"
   },
-  "license": "MIT",
-  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "devDependencies": {
     "tsup": "^8.3.5",
     "typescript": "^5.7.3"
   },
-  "dependencies": {
-    "axios": "^1.7.9"
-  }
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts"
+  },
+  "type": "module",
+  "types": "dist/index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,10 @@
-import axios from "axios";
-import {
-  Product,
-  ScrapeOptions,
-} from "./types";
+import { Product, ScrapeOptions } from "./types";
 import { isValidURL } from "./url";
 
-const shopifyIndicators = [/myshopify\.com/i];
-
-export async function scrape(url: string, { limit = Infinity, onProgress }: ScrapeOptions = {}) {
+export async function scrape(
+  url: string,
+  { limit = Infinity, onProgress }: ScrapeOptions = {},
+) {
   const isValid = await isValidURL(url);
   if (!isValid) return null;
 
@@ -16,9 +13,10 @@ export async function scrape(url: string, { limit = Infinity, onProgress }: Scra
 
   while (data.length < limit) {
     const pageLimit = Math.min(250, limit - data.length);
-    const { data: requestedData } = await axios.get(
-      `${url}/products.json/?limit=${pageLimit}&page=${page}`
-    );
+
+    const requestedData = await fetch(
+      `${url}/products.json/?limit=${pageLimit}&page=${page}`,
+    ).then((res) => res.json());
 
     if (!requestedData?.products?.length) break;
 

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,9 +1,8 @@
-import axios from "axios";
 const shopifyIndicators = [/myshopify\.com/i];
 
 export async function isValidURL(url: string): Promise<boolean> {
   try {
-    const { data: html } = await axios.get(url);
+    const html = await fetch(url).then((res) => res.text());
     return shopifyIndicators.some((pattern) => pattern.test(html));
   } catch {
     return false;


### PR DESCRIPTION
This PR introduces multiple changes to ditch axios in favor of using the native fetch API.


also fixes the outdated package-lock & remove the unused `shopifyIndicators` array